### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,7 @@
   ],
   "description" : "a perl6 implementation of the unofficial code submitter for Aizu Online Judge( http://judge.u-aizu.ac.jp/onlinejudge/index.jsp ).",
   "name" : "App::AizuOnlineJudge",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "App::AizuOnlineJudge" : "lib/App/AizuOnlineJudge.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license