### PR TITLE
Fix version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -23,5 +23,5 @@
   "source-url" : "git://github.com/titsuki/p6-App-AizuOnlineJudge.git",
   "tags" : [ ],
   "test-depends" : [ ],
-  "version" : "*"
+  "version" : "1.001001"
 }


### PR DESCRIPTION
WhateverStar version is only valid as a *matcher* for versions, not as an identifier of a distribution's version.